### PR TITLE
fix typo in index.coffee

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -19,7 +19,7 @@ phabs_features = if process.env.PHABS_ENABLED_FEATURES?
 else if process.env.PHABS_DISABLED_FEATURES?
   disabled = process.env.PHABS_DISABLED_FEATURES.split(',')
   phabs_available_features.reduce (a, f) ->
-    a.push f if f not in disableda
+    a.push f if f not in disabled
     a
   , [ ]
 else


### PR DESCRIPTION
Error occurs when using PHABS_DISABLED_FEATURES