### PR TITLE
Pass project / tag phid in an array to projects.add and projects.remove

### DIFF
--- a/lib/phabricator.coffee
+++ b/lib/phabricator.coffee
@@ -736,7 +736,7 @@ class Phabricator
           .then (projectData) =>
             phid = projectData.data.phid
             if phid not in item.projectPHIDs
-              payload.data.push({ type: 'projects.add', value: phid })
+              payload.data.push({ type: 'projects.add', value: [phid] })
               payload.messages.push("been added to #{r[2]}")
             else
               payload.notices.push("T#{item.id} is already in #{r[2]}")
@@ -753,7 +753,7 @@ class Phabricator
           .then (projectData) =>
             phid = projectData.data.phid
             if phid in item.projectPHIDs
-              payload.data.push({ type: 'projects.remove', value: phid })
+              payload.data.push({ type: 'projects.remove', value: [phid] })
               payload.messages.push("been removed from #{r[2]}")
             else
               payload.notices.push("T#{item.id} is already not in #{r[2]}")


### PR DESCRIPTION
Was seeing the following errors when trying to use `.phab in [project]` to add a task to a project / tag:
```
Exception when processing transaction of type "projects.add": Error while reading "value": Expected a list, but value is not a list.
```

And this similar error when using `.phab not in [project]` to remove as task from a project / tag:
```
Exception when processing transaction of type "projects.remove": Error while reading "value": Expected a list, but value is not a list.
```

Hopefully this PR will fix that.