### PR TITLE
Add functionality to hear Differential Revisions too

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ There is possibility to only react to certain item type too, by setting the `PHA
         the plugin will watch if it sees 
         - T[0-9]+ for tasks (of Maniphest)
         - P[0-9]+ for pastes 
+        - D[0-9]+ for differential revisions
         - F[0-9]+ for files 
         - M[0-9]+ for mocks (of Pholio)
         - B[0-9]+ for builds (of Harbormaster)

--- a/lib/phabricator.coffee
+++ b/lib/phabricator.coffee
@@ -58,6 +58,7 @@ class Phabricator
     'Q', # ponder
     'L', # legalpad
     'V'  # polls
+    'D', # diffs
   ]
 
   constructor: (@robot, env) ->

--- a/scripts/phabs_hear.coffee
+++ b/scripts/phabs_hear.coffee
@@ -84,7 +84,7 @@ module.exports = (robot) ->
             .catch (e) ->
               msg.send "oops #{type}#{id} #{e}"
 
-          when /^(M|B|Q|L|V)$/.test type
+          when /^(D|M|B|Q|L|V)$/.test type
             phab.genericInfo("#{type}#{id}")
             .then (body) ->
               if Object.keys(body.result).length < 1

--- a/test/phabs_hear_test.coffee
+++ b/test/phabs_hear_test.coffee
@@ -718,9 +718,13 @@ describe 'phabs_hear module', ->
           .get('/api/phid.lookup')
           .reply(200, { result: {
             'D55': {
-              'status': 'open',
-              'title': 'some diff',
-              'uri': 'http://example.com/D55'
+              'phid': 'PHID-DREV-hqztsdcva3jkucu4mmv2',
+              'uri': 'http://example.com/D55',
+              'typeName': 'Differential Revision',
+              'type': 'DREV',
+              'name': 'D55',
+              'fullName': 'D55: some diff',
+              'status': 'open'
             }
           } })
 
@@ -743,9 +747,13 @@ describe 'phabs_hear module', ->
           .get('/api/phid.lookup')
           .reply(200, { result: {
             'D55': {
-              'status': 'closed',
-              'title': 'some diff',
-              'uri': 'http://example.com/D55'
+              'phid': 'PHID-DREV-hqztsdcva3jkucu4mmv2',
+              'uri': 'http://example.com/D55',
+              'typeName': 'Differential Revision',
+              'type': 'DREV',
+              'name': 'D55',
+              'fullName': 'D55: some diff',
+              'status': 'closed'
             }
           } })
 

--- a/test/phabs_hear_test.coffee
+++ b/test/phabs_hear_test.coffee
@@ -717,9 +717,11 @@ describe 'phabs_hear module', ->
         nock(process.env.PHABRICATOR_URL)
           .get('/api/phid.lookup')
           .reply(200, { result: {
-            status: 'open',
-            title: 'some diff',
-            uri: 'http://example.com/D55'
+            'D55': {
+              'status': 'open',
+              'title': 'some diff',
+              'uri': 'http://example.com/D55'
+            }
           } })
 
       afterEach ->
@@ -740,9 +742,11 @@ describe 'phabs_hear module', ->
         nock(process.env.PHABRICATOR_URL)
           .get('/api/phid.lookup')
           .reply(200, { result: {
-            status: 'closed',
-            title: 'some diff',
-            uri: 'http://example.com/D55'
+            'D55': {
+              'status': 'closed',
+              'title': 'some diff',
+              'uri': 'http://example.com/D55'
+            }
           } })
 
       afterEach ->

--- a/test/phabs_hear_test.coffee
+++ b/test/phabs_hear_test.coffee
@@ -695,6 +695,69 @@ describe 'phabs_hear module', ->
           expect(hubotResponse()).to.eql 'V30: This is a poll (closed)'
 
   # ---------------------------------------------------------------------------------
+  context 'someone talks about a diff', ->
+    context 'when the diff is unknown', ->
+      beforeEach ->
+        do nock.disableNetConnect
+        nock(process.env.PHABRICATOR_URL)
+          .get('/api/phid.lookup')
+          .reply(200, { result: { } })
+
+      afterEach ->
+        nock.cleanAll()
+
+      context 'whatever about D555555 or something', ->
+        hubot 'whatever about D555555 or something'
+        it "warns the user that this Diff doesn't exist", ->
+          expect(hubotResponse()).to.eql 'oops D555555 was not found.'
+
+    context 'when it is an open diff', ->
+      beforeEach ->
+        do nock.disableNetConnect
+        nock(process.env.PHABRICATOR_URL)
+          .get('/api/phid.lookup')
+          .reply(200, { result: {
+            status: 'open',
+            title: 'some diff',
+            uri: 'http://example.com/D55'
+          } })
+
+      afterEach ->
+        nock.cleanAll()
+
+      context 'whatever about D55 or something', ->
+        hubot 'whatever about D55 or something'
+        it "gives information about the open Diff, including uri", ->
+          expect(hubotResponse()).to.eql 'http://example.com/D55 - some diff'
+      context 'whatever about http://example.com/D55 or something', ->
+        hubot 'whatever about http://example.com/D55 or something'
+        it "gives information about the open Diff, without uri", ->
+          expect(hubotResponse()).to.eql 'D55: some diff'
+
+    context 'when it is a closed diff', ->
+      beforeEach ->
+        do nock.disableNetConnect
+        nock(process.env.PHABRICATOR_URL)
+          .get('/api/phid.lookup')
+          .reply(200, { result: {
+            status: 'closed',
+            title: 'some diff',
+            uri: 'http://example.com/D55'
+          } })
+
+      afterEach ->
+        nock.cleanAll()
+
+      context 'whatever about D55 or something', ->
+        hubot 'whatever about D55 or something'
+        it 'gives information about the closed Diff, including uri', ->
+          expect(hubotResponse()).to.eql 'http://example.com/D55 - some diff (closed)'
+      context 'whatever about http://example.com/D55 or something', ->
+        hubot 'whatever about http://example.com/D55 or something'
+        it 'gives information about the closed Diff, without uri', ->
+          expect(hubotResponse()).to.eql 'D55: some diff (closed)'
+
+  # ---------------------------------------------------------------------------------
   context 'someone talks about a commit', ->
     context 'when the commit is unknown', ->
       beforeEach ->


### PR DESCRIPTION
This allows hubot to listen for mentions of a Differential Revision, and respond using `genericInfo` from phabricator lib, calling the `phid.lookup` endpoint, similar to how it's currently behaving for mocks, builds, etc.